### PR TITLE
Standardize console creation

### DIFF
--- a/client/ayon_photoshop/hooks/pre_launch_args.py
+++ b/client/ayon_photoshop/hooks/pre_launch_args.py
@@ -27,7 +27,7 @@ def get_launch_kwargs(kwargs):
     if platform.system().lower() != "windows":
         return kwargs
 
-    if not is_using_ayon_console():
+    if is_using_ayon_console():
         kwargs.update({
             "creationflags": subprocess.CREATE_NEW_CONSOLE
         })


### PR DESCRIPTION
## Changelog Description
If AYON is triggered from `ayon_console`, CREATE_NEW_CONSOLE should be used. Same as in AE, here used wrong, most likely because some superfluous dev commit.

## Testing notes:

1. open PS from `ayon.exe` - shouldn't create separate console
2. open PS from `ayon_console.exe` - shouldn't create separate console
