### PR TITLE
Add enum resolver for task types

### DIFF
--- a/server/settings/workfile_builder.py
+++ b/server/settings/workfile_builder.py
@@ -2,6 +2,7 @@ from ayon_server.settings import (
     BaseSettingsModel,
     SettingsField,
     MultiplatformPathModel,
+    task_types_enum,
 )
 
 
@@ -10,6 +11,7 @@ class CustomBuilderTemplate(BaseSettingsModel):
     task_types: list[str] = SettingsField(
         default_factory=list,
         title="Task types",
+        enum_resolver=task_types_enum
     )
 
     path: MultiplatformPathModel = SettingsField(


### PR DESCRIPTION

## Changelog description
- Integrated `task_types_enum` into the task types field
- Updated settings model to enhance task type handling

## Testing steps
- open settings at `ayon+settings://photoshop/workfile_builder/custom_templates`
- create new preset and see that task type is enumerator