### PR TITLE
Support tga format for publishing image product type.

### DIFF
--- a/client/ayon_photoshop/api/extension/host/index.jsx
+++ b/client/ayon_photoshop/api/extension/host/index.jsx
@@ -174,6 +174,10 @@ function saveAs(output_path, ext, as_copy){
       saveOptions.interlaced = true;
       saveOptions.transparency = true;
     }
+    if (ext == 'tga'){
+        saveOptions = new TargaSaveOptions();
+        saveOptions.alphaChannels = true;
+      }
     if (ext == 'psd'){
         saveOptions = null;
         return app.activeDocument.saveAs(new File(saveName));       

--- a/client/ayon_photoshop/api/extension/host/index.jsx
+++ b/client/ayon_photoshop/api/extension/host/index.jsx
@@ -177,7 +177,8 @@ function saveAs(output_path, ext, as_copy){
     if (ext == 'tga'){
         saveOptions = new TargaSaveOptions();
         saveOptions.alphaChannels = true;
-      }
+        saveOptions.rleCompression = true;
+    }
     if (ext == 'psd'){
         saveOptions = null;
         return app.activeDocument.saveAs(new File(saveName));       

--- a/client/ayon_photoshop/api/extension/host/index.jsx
+++ b/client/ayon_photoshop/api/extension/host/index.jsx
@@ -177,7 +177,6 @@ function saveAs(output_path, ext, as_copy){
     if (ext == 'tga'){
         saveOptions = new TargaSaveOptions();
         saveOptions.alphaChannels = true;
-        saveOptions.rleCompression = true;
     }
     if (ext == 'psd'){
         saveOptions = null;

--- a/client/ayon_photoshop/plugins/publish/extract_image.py
+++ b/client/ayon_photoshop/plugins/publish/extract_image.py
@@ -61,17 +61,24 @@ class ExtractImage(pyblish.api.ContextPlugin):
                     for extracted_id in extract_ids:
                         stub.set_visible(extracted_id, True)
 
-                    file_basename = os.path.splitext(
+                    file_basename, workfile_extension = os.path.splitext(
                         stub.get_active_document_name()
-                    )[0]
+                    )
+                    workfile_extension = workfile_extension.strip(".")
+
                     for extension in self.formats:
                         _filename = "{}.{}".format(file_basename,
-                                                   extension)
+                                                    extension)
                         files[extension] = _filename
 
                         full_filename = os.path.join(staging_dir,
                                                      _filename)
-                        stub.saveAs(full_filename, extension, True)
+                        if extension == "tga":
+                            self._save_image_to_targa(
+                                stub, full_filename, extension, workfile_extension
+                            )
+                        else:
+                            stub.saveAs(full_filename, extension, True)
                         self.log.info(f"Extracted: {extension}")
 
                     representations = []
@@ -100,3 +107,19 @@ class ExtractImage(pyblish.api.ContextPlugin):
         from ayon_core.pipeline.publish import get_instance_staging_dir
 
         return get_instance_staging_dir(instance)
+
+
+    def _save_image_to_targa(self, stub, full_filename, extension, workfile_extension):
+        """Hacky way to save image in targa. Save the psd file
+        in quiet mode with targa options first and then convert it into targa
+        ***Caution to use it.
+
+        Args:
+            stub (RPC stub): stub to call method
+            full_filename (str): full published filename
+            extension (str): published extension
+            workfile_extension (str): workfile extension
+        """
+        src_file = full_filename.replace(extension, workfile_extension)
+        stub.saveAs(src_file, extension, True)
+        os.rename(src_file, full_filename)

--- a/client/ayon_photoshop/plugins/publish/extract_image.py
+++ b/client/ayon_photoshop/plugins/publish/extract_image.py
@@ -121,5 +121,6 @@ class ExtractImage(pyblish.api.ContextPlugin):
             workfile_extension (str): workfile extension
         """
         src_file = full_filename.replace(extension, workfile_extension)
-        stub.saveAs(src_file, extension, True)
-        os.rename(src_file, full_filename)
+        stub.saveAs(full_filename, extension, True)
+        if os.path.exists(src_file):
+            os.rename(src_file, full_filename)

--- a/client/ayon_photoshop/plugins/publish/extract_image.py
+++ b/client/ayon_photoshop/plugins/publish/extract_image.py
@@ -21,7 +21,7 @@ class ExtractImage(pyblish.api.ContextPlugin):
     hosts = ["photoshop"]
 
     families = ["image", "background"]
-    formats = ["png", "jpg"]
+    formats = ["png", "jpg", "tga"]
     settings_category = "photoshop"
 
     def process(self, context):

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -181,7 +181,8 @@ DEFAULT_PUBLISH_SETTINGS = {
     "ExtractImage": {
         "formats": [
             "png",
-            "jpg"
+            "jpg",
+            "tga"
         ]
     },
     "ExtractReview": {


### PR DESCRIPTION
## Changelog Description
This PR is to add tga support as image format for publishing image product type.
Resolve https://github.com/ynput/ayon-photoshop/issues/25

## Additional review information
The method takes reference from how photoshop save the targa file with targa options in psd format and convert it into targa. It is some hacky way to do so use it as caution.

## Testing notes:
1. Create Image Instance
2. Select tga as exported image format option.
3. Publish 
