### PR TITLE
Feature: Auto install extension

### DIFF
--- a/client/ayon_photoshop/hooks/pre_launch_install_ayon_extension.py
+++ b/client/ayon_photoshop/hooks/pre_launch_install_ayon_extension.py
@@ -39,8 +39,9 @@ class InstallAyonExtensionToPhotoshop(PreLaunchHook):
         self.log.info("Installing AYON Photoshop extension.")
 
         target_path = Path(
-            platformdirs.user_data_dir("Adobe", roaming=True),  # roaming is useful for windows
-            "CEP/extensions/io.ynput.PS.panel"
+            # roaming is applicable for windows
+            platformdirs.user_data_dir(roaming=True),
+            "Adobe/CEP/extensions/io.ynput.PS.panel"
         )
 
         extension_path = Path(

--- a/client/ayon_photoshop/hooks/pre_launch_install_ayon_extension.py
+++ b/client/ayon_photoshop/hooks/pre_launch_install_ayon_extension.py
@@ -1,0 +1,148 @@
+from pathlib import Path
+from zipfile import ZipFile
+import xml.etree.ElementTree as ET
+from shutil import rmtree
+
+import platformdirs
+
+from ayon_photoshop import PHOTOSHOP_ADDON_ROOT
+from ayon_applications import PreLaunchHook, LaunchTypes
+
+
+class InstallAyonExtensionToPhotoshop(PreLaunchHook):
+    """
+    Automatically 'installs' the AYON Photoshop extension.
+
+    Checks if Photoshop already has the extension in the relevant folder,
+    will try to create that folder and unzip the extension if not.
+    """
+
+    app_groups = {"photoshop"}
+
+    order = 1
+    launch_types = {LaunchTypes.local}
+
+    def execute(self):
+        try:
+            settings = self.data["project_settings"]["photoshop"]
+            if not settings["auto_install_extension"]:
+                return
+            self.inner_execute()
+
+        except Exception:
+            self.log.warning(
+                "Processing of {} crashed.".format(self.__class__.__name__),
+                exc_info=True,
+            )
+
+    def inner_execute(self):
+        self.log.info("Installing AYON Photoshop extension.")
+
+        target_path = Path(
+            platformdirs.user_data_dir("Adobe", roaming=True),  # roaming is useful for windows
+            "CEP/extensions/io.ynput.PS.panel"
+        )
+
+        extension_path = Path(
+            PHOTOSHOP_ADDON_ROOT,
+            "api",
+            "extension.zxp",
+        )
+
+        # Extension already installed, compare the versions
+        if target_path.is_dir():
+            self.log.info(
+                f"The extension already exists at: {target_path}. "
+                f"Comparing versions.."
+            )
+            if not self._compare_extension_versions(
+                target_path, extension_path
+            ):
+                return
+
+        try:
+            self.log.debug(f"Creating directory: {target_path}")
+            target_path.mkdir(parents=True, exist_ok=True)
+
+            with ZipFile(extension_path, "r") as archive:
+                archive.extractall(path=target_path)
+            self.log.info("Successfully installed AYON extension")
+
+        except OSError as error:
+            self.log.warning(f"OS error has occured: {error}")
+
+        except PermissionError as error:
+            self.log.warning(f"Permissions error has occured: {error}")
+
+        except Exception as error:
+            self.log.warning(f"An unexpected error occured: {error}")
+
+    def _compare_extension_versions(
+        self, target_path: Path, extension_path: Path
+    ) -> bool:
+        try:
+            # opens the existing extension manifest to get the Version attr
+            with target_path.joinpath("CSXS", "manifest.xml").open("rb") as xml_file:
+                installed_version = (
+                    ET.parse(xml_file)
+                    .getroot()
+                    .attrib.get("ExtensionBundleVersion")
+                )
+            self.log.debug(
+                f"Current extension version found: {installed_version}"
+            )
+
+            if not installed_version:
+                self.log.warning(
+                    "Unable to resolve the currently installed extension "
+                    "version. Cancelling.."
+                )
+                return False
+
+            # opens the .zxp manifest to get the Version attribute.
+            with ZipFile(extension_path, "r") as archive:
+                xml_file = archive.open("CSXS/manifest.xml")
+                new_version = (
+                    ET.parse(xml_file)
+                    .getroot()
+                    .attrib.get("ExtensionBundleVersion")
+                )
+                if not new_version:
+                    self.log.warning(
+                        "Unable to resolve the new extension version. "
+                        "Cancelling.."
+                    )
+                self.log.debug(f"New extension version found: {new_version}")
+
+                # compare the two versions, a simple == is enough since
+                # we don't care if the version increments or decrements
+                # if they match nothing happens.
+                if installed_version == new_version:
+                    self.log.info("Versions matched. Cancelling..")
+                    return False
+
+                # remove the existing addon
+                self.log.info(
+                    "Version mismatch found. Removing old extensions.."
+                )
+                rmtree(target_path)
+                return True
+
+        except PermissionError as error:
+            self.log.warning(
+                "Permissions error has occurred while comparing "
+                f"versions: {error}"
+            )
+            return False
+
+        except OSError as error:
+            self.log.warning(
+                f"OS error has occured while comparing versions: {error}"
+            )
+            return False
+
+        except Exception as error:
+            self.log.warning(
+                f"An unexpected error occured when comparing version: {error}"
+            )
+            return False

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -4,3 +4,4 @@ description="AYON Phostoshop addon."
 
 [ayon.runtimeDependencies]
 wsrpc_aiohttp = "^3.1.1" # websocket server
+platformdirs = "*"

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -9,6 +9,12 @@ from .workfile_builder import WorkfileBuilderPlugin
 class PhotoshopSettings(BaseSettingsModel):
     """Photoshop Project Settings."""
 
+    auto_install_extension: bool = SettingsField(
+        False,
+        title="Install AYON Extension",
+        description="Triggers pre-launch hook which installs extension."
+    )
+
     imageio: PhotoshopImageIOModel = SettingsField(
         default_factory=PhotoshopImageIOModel,
         title="OCIO config"
@@ -31,6 +37,7 @@ class PhotoshopSettings(BaseSettingsModel):
 
 
 DEFAULT_PHOTOSHOP_SETTING = {
+    "auto_install_extension": False,
     "create": DEFAULT_CREATE_SETTINGS,
     "publish": DEFAULT_PUBLISH_SETTINGS,
     "workfile_builder": {


### PR DESCRIPTION
## Changelog Description
Auto install Ayon `.zxp` extension with a launch hook.

## Additional review information
Works for bath Windows and OSX.
Use of `platformdirs` to keep code concise, by any version because we don't need any specific one as the use is very basic.

## Testing notes:
1. Create and upload the addon
2. Add it to a bundle
3. Build dependencies of the bundle
4. Assign de deps package to the bundle
5. Start launcher
6. Open a task using Photoshop (make sure you have no installed version of the extension already)
7. The extension is installed