### PR TITLE
Disable ExtractLayers by default

### DIFF
--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -219,7 +219,7 @@ DEFAULT_PUBLISH_SETTINGS = {
         }
     },
     "ExtractLayers": {
-        "enabled": True,
+        "enabled": False,
         "merge_layersets": False
     }
 }


### PR DESCRIPTION
## Changelog Description
New functionality to extract .psd as a new image representation should be disabled by default.
