### PR TITLE
Refactored ExtractReview to more use global one

### DIFF
--- a/client/ayon_photoshop/plugins/publish/extract_sources_review.py
+++ b/client/ayon_photoshop/plugins/publish/extract_sources_review.py
@@ -2,10 +2,6 @@ import os
 import shutil
 from PIL import Image
 
-from ayon_core.lib import (
-    run_subprocess,
-    get_ffmpeg_tool_args,
-)
 from ayon_core.pipeline import publish
 from ayon_photoshop import api as photoshop
 
@@ -27,7 +23,7 @@ class ExtractSourcesReview(publish.Extractor):
         or comp.)
     """
 
-    label = "Prepare Sources for Review"
+    label = "Extract Sources for Review"
     hosts = ["photoshop"]
     families = ["review"]
     settings_category = "photoshop"
@@ -63,24 +59,23 @@ class ExtractSourcesReview(publish.Extractor):
             self.log.debug("Extract layers to image sequence.")
             img_list = self._save_sequence_images(staging_dir, layers)
 
+            instance.data["frameStart"] = 0
+            instance.data["frameEnd"] = len(img_list) - 1
+            instance.data["fps"] = fps
+
             instance.data["representations"].append(
                 {
-                    "name": "jpg_intermediate",
+                    "name": "jpg",
                     "ext": "jpg",
                     "files": img_list,
                     "stagingDir": staging_dir,
-                    "frameStart": 1,
-                    "frameEnd": len(img_list),
+                    "frameStart": instance.data["frameStart"],
+                    "frameEnd": instance.data["frameEnd"],
                     "fps": fps,
                     "tags": ["review"],
-                    "delete": True  # TODO
                 }
             )
 
-            instance.data["thumbnailSource"] = os.path.join(
-                staging_dir,
-                img_list[0]
-            )
         else:
             self.log.debug("Extract layers to flatten image.")
             img_file = self._save_flatten_image(staging_dir, layers)

--- a/client/ayon_photoshop/plugins/publish/extract_sources_review.py
+++ b/client/ayon_photoshop/plugins/publish/extract_sources_review.py
@@ -84,38 +84,9 @@ class ExtractSourcesReview(publish.Extractor):
         else:
             self.log.debug("Extract layers to flatten image.")
             img_file = self._save_flatten_image(staging_dir, layers)
-
-            repre_skeleton.update({
-                "files": img_file,
-            })
-            processed_img_names = [img_file]
-
-        instance.data["representations"].append(repre_skeleton)
-
-        ffmpeg_args = get_ffmpeg_tool_args("ffmpeg")
+            instance.data["thumbnailSource"] = img_file
 
         instance.data["stagingDir"] = staging_dir
-
-        source_files_pattern = os.path.join(staging_dir,
-                                            self.output_seq_filename)
-        source_files_pattern = self._check_and_resize(processed_img_names,
-                                                      source_files_pattern,
-                                                      staging_dir)
-        self._generate_thumbnail(
-            list(ffmpeg_args),
-            instance,
-            source_files_pattern,
-            staging_dir)
-
-        no_of_frames = len(processed_img_names)
-        if no_of_frames > 1:
-            self._generate_mov(
-                list(ffmpeg_args),
-                instance,
-                fps,
-                no_of_frames,
-                source_files_pattern,
-                staging_dir)
 
         self.log.info(f"Extracted {instance} to {staging_dir}")
 

--- a/client/ayon_photoshop/plugins/publish/extract_sources_review.py
+++ b/client/ayon_photoshop/plugins/publish/extract_sources_review.py
@@ -10,7 +10,7 @@ from ayon_core.pipeline import publish
 from ayon_photoshop import api as photoshop
 
 
-class ExtractReview(publish.Extractor):
+class ExtractSourcesReview(publish.Extractor):
     """
         Produce a flattened or sequence image files from all 'image' instances.
 
@@ -26,7 +26,7 @@ class ExtractReview(publish.Extractor):
         or comp.)
     """
 
-    label = "Extract Review"
+    label = "Prepare Sources for Review"
     hosts = ["photoshop"]
     families = ["review"]
     settings_category = "photoshop"

--- a/client/ayon_photoshop/plugins/publish/extract_sources_review.py
+++ b/client/ayon_photoshop/plugins/publish/extract_sources_review.py
@@ -27,6 +27,7 @@ class ExtractSourcesReview(publish.Extractor):
     hosts = ["photoshop"]
     families = ["review"]
     settings_category = "photoshop"
+    order = publish.Extractor.order - 0.28
 
     # Extract Options
     make_image_sequence = None

--- a/client/ayon_photoshop/plugins/publish/extract_sources_review.py
+++ b/client/ayon_photoshop/plugins/publish/extract_sources_review.py
@@ -226,7 +226,7 @@ class ExtractSourcesReview(publish.Extractor):
 
             stub.saveAs(output_image_path, 'jpg', True)
 
-        return img_filename
+        return output_image_path
 
     def _save_sequence_images(self, staging_dir, layers):
         """Creates separate images from 'layers' into 'staging_dir'.

--- a/client/ayon_photoshop/plugins/publish/extract_sources_review.py
+++ b/client/ayon_photoshop/plugins/publish/extract_sources_review.py
@@ -63,13 +63,24 @@ class ExtractSourcesReview(publish.Extractor):
             self.log.debug("Extract layers to image sequence.")
             img_list = self._save_sequence_images(staging_dir, layers)
 
-            repre_skeleton.update({
-                "frameStart": 0,
-                "frameEnd": len(img_list),
-                "fps": fps,
-                "files": img_list,
-            })
-            processed_img_names = img_list
+            instance.data["representations"].append(
+                {
+                    "name": "jpg_intermediate",
+                    "ext": "jpg",
+                    "files": img_list,
+                    "stagingDir": staging_dir,
+                    "frameStart": 1,
+                    "frameEnd": len(img_list),
+                    "fps": fps,
+                    "tags": ["review"],
+                    "delete": True  # TODO
+                }
+            )
+
+            instance.data["thumbnailSource"] = os.path.join(
+                staging_dir,
+                img_list[0]
+            )
         else:
             self.log.debug("Extract layers to flatten image.")
             img_file = self._save_flatten_image(staging_dir, layers)

--- a/client/ayon_photoshop/plugins/publish/extract_sources_review.py
+++ b/client/ayon_photoshop/plugins/publish/extract_sources_review.py
@@ -178,7 +178,13 @@ class ExtractSourcesReview(publish.Extractor):
         return source_files_pattern
 
     def _get_layers_from_image_instances(self, instance):
-        """Collect all layers from 'instance'.
+        """Collect all layers from image instance(s)
+
+        If `instance` is `image` it returns just layers out of it to create
+        separate review per instance.
+
+        If `instance` is (most likely) `review`, it collects all layers from
+        published instances to create one review from all of them.
 
         Returns:
             (list) of PSItem
@@ -192,6 +198,7 @@ class ExtractSourcesReview(publish.Extractor):
             layers.append(instance.data["layer"])
             return layers
 
+        # collect all layers from published image instances
         for image_instance in instance.context:
             if image_instance.data["productType"] != "image":
                 continue
@@ -222,7 +229,9 @@ class ExtractSourcesReview(publish.Extractor):
         return img_filename
 
     def _save_sequence_images(self, staging_dir, layers):
-        """Creates separate flat images from 'layers' into 'staging_dir'.
+        """Creates separate images from 'layers' into 'staging_dir'.
+
+        `layers` are actually groups matching instances.
 
         Used as source for multi frames .mov to review at once.
         Returns:

--- a/client/ayon_photoshop/plugins/publish/extract_sources_review.py
+++ b/client/ayon_photoshop/plugins/publish/extract_sources_review.py
@@ -47,33 +47,17 @@ class ExtractSourcesReview(publish.Extractor):
         layers = self._get_layers_from_image_instances(instance)
         self.log.info("Layers image instance found: {}".format(layers))
 
-        repre_name = "jpg"
-        repre_skeleton = {
-            "name": repre_name,
-            "ext": "jpg",
-            "stagingDir": staging_dir,
-            "tags": self.jpg_options['tags'],
-        }
-
         if instance.data["productType"] != "review":
             self.log.debug(
                 "Existing extracted file from image product type used."
             )
-            # enable creation of review, without this jpg review would clash
-            # with jpg of the image product type
-            output_name = repre_name
-            repre_name = "{}_{}".format(repre_name, output_name)
-            repre_skeleton.update({"name": repre_name,
-                                   "outputName": output_name})
 
             img_file = self.output_seq_filename % 0
-            self._prepare_file_for_image_product_type(
+            thumbnail_source_path = self._prepare_file_for_image_product_type(
                 img_file, instance, staging_dir
             )
-            repre_skeleton.update({
-                "files": img_file,
-            })
-            processed_img_names = [img_file]
+
+            instance.data["thumbnailSource"] = thumbnail_source_path
         elif self.make_image_sequence and len(layers) > 1:
             self.log.debug("Extract layers to image sequence.")
             img_list = self._save_sequence_images(staging_dir, layers)

--- a/client/ayon_photoshop/plugins/publish/extract_sources_review.py
+++ b/client/ayon_photoshop/plugins/publish/extract_sources_review.py
@@ -17,7 +17,8 @@ class ExtractSourcesReview(publish.Extractor):
         If no 'image' instance is created, it produces flattened image from
         all visible layers.
 
-        It creates review, thumbnail and mov representations.
+        It can also create separate reviews per `image` instance if necessary.
+        (toggle on an instance in Publisher UI).
 
         'review' family could be used in other steps as a reference, as it
         contains flattened image by default. (Eg. artist could load this

--- a/client/ayon_photoshop/plugins/publish/extract_sources_review.py
+++ b/client/ayon_photoshop/plugins/publish/extract_sources_review.py
@@ -32,8 +32,6 @@ class ExtractSourcesReview(publish.Extractor):
     settings_category = "photoshop"
 
     # Extract Options
-    jpg_options = None
-    mov_options = None
     make_image_sequence = None
     max_downscale_size = 8192
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -104,7 +104,7 @@ class ExtractImagePlugin(BaseSettingsModel):
     )
 
 
-class ExtractReviewPlugin(BaseSettingsModel):
+class ExtractSourceReviewPlugin(BaseSettingsModel):
     make_image_sequence: bool = SettingsField(
         False,
         title="Make an image sequence instead of flatten image"
@@ -116,16 +116,6 @@ class ExtractReviewPlugin(BaseSettingsModel):
         description="FFMpeg can only handle limited resolution for creation of review and/or thumbnail",  # noqa
         gt=300,  # greater than
         le=16384,  # less or equal
-    )
-
-    jpg_options: ExtractedOptions = SettingsField(
-        title="Extracted jpg Options",
-        default_factory=ExtractedOptions
-    )
-
-    mov_options: ExtractedOptions = SettingsField(
-        title="Extracted mov Options",
-        default_factory=ExtractedOptions
     )
 
 
@@ -166,9 +156,9 @@ class PhotoshopPublishPlugins(BaseSettingsModel):
         default_factory=ExtractImagePlugin,
     )
 
-    ExtractReview: ExtractReviewPlugin = SettingsField(
-        title="Extract Review",
-        default_factory=ExtractReviewPlugin,
+    ExtractSourcesReview: ExtractSourceReviewPlugin = SettingsField(
+        title="Extract Sources for Review",
+        default_factory=ExtractSourceReviewPlugin,
     )
 
     ExtractLayers: ExtractLayersPlugin = SettingsField(
@@ -200,23 +190,9 @@ DEFAULT_PUBLISH_SETTINGS = {
             "tga"
         ]
     },
-    "ExtractReview": {
+    "ExtractSourcesReview": {
         "make_image_sequence": False,
         "max_downscale_size": 8192,
-        "jpg_options": {
-            "tags": [
-                "review",
-                "ftrackreview",
-                "webreview"
-            ]
-        },
-        "mov_options": {
-            "tags": [
-                "review",
-                "ftrackreview",
-                "webreview"
-            ]
-        }
     },
     "ExtractLayers": {
         "enabled": False,


### PR DESCRIPTION
## Changelog Description
Photoshop had for historical reasons separate `ExtractReview` which caused issues in split configuration and much simpler control of final review. This PR is trying to move to global `ExtractReview` as much as possible.

This way reviews in PS are following global configuration more closely and could be tweaked in much higher detail.

Notable changes:
- `make_image_sequence` config now produce `.mp4` (with burnin) as that is a default in global Settings
- thumbnail is not scaled down to 300 as previously

## Additional review information
I am not sure if `ExtractThumbnailFromSource` should be pretty simple and not be providing any scaling or other tweaks and should depend on whatever is sent to it, or we should add it there also.

Previously thumbnail in PS was scaled down (via using ffmpeg ` "-vf", "scale=300:-1",`), `ExtractThumbnailFromSource` doesn't provide any scaling whatsoever. 
Should we add scaling down into this plugin and expose it in Settings? (maybe in similar fashion as `ExtractThumbnail` has it? https://github.com/ynput/ayon-core/blob/develop/server/settings/publish_plugins.py#L312)


## Testing notes:
1. export in PS with various modes (review on image instance(s), just `review` instance, `review` instance with `make_image_sequence` (with `image` instances created and enabled).
2. compare results with older implementation
