### PR TITLE
Move from using env var to Tools Settings to open Workfiles on startup

### DIFF
--- a/client/ayon_photoshop/api/lib.py
+++ b/client/ayon_photoshop/api/lib.py
@@ -36,6 +36,13 @@ def main(*subprocess_args):
     launcher = ProcessLauncher(subprocess_args)
     launcher.start()
 
+    env_workfiles_on_launch = os.getenv(
+        "AYON_PHOTOSHOP_WORKFILES_ON_LAUNCH",
+        # Backwards compatibility
+        os.getenv("AVALON_PHOTOSHOP_WORKFILES_ON_LAUNCH", True)
+    )
+    workfiles_on_launch = env_value_to_bool(value=env_workfiles_on_launch)
+
     if is_in_tests():
         manager = AddonsManager()
         photoshop_addon = manager["photoshop"]
@@ -56,8 +63,7 @@ def main(*subprocess_args):
             "ClosePS",
             is_in_tests()
         )
-    elif env_value_to_bool("AVALON_PHOTOSHOP_WORKFILES_ON_LAUNCH",
-                           default=True):
+    elif workfiles_on_launch:
 
         launcher.execute_in_main_thread(
             host_tools.show_workfiles,

--- a/client/ayon_photoshop/hooks/pre_launch_args.py
+++ b/client/ayon_photoshop/hooks/pre_launch_args.py
@@ -77,6 +77,10 @@ class PhotoshopPrelaunchHook(PreLaunchHook):
         ):
             new_launch_args.append(workfile_path)
 
+        workfile_startup = self.data.get("workfile_startup", False)
+        self.launch_context.env["AYON_PHOTOSHOP_WORKFILES_ON_LAUNCH"] = (
+            str(workfile_startup).lower()
+        )
         # Append as whole list as these arguments should not be separated
         self.launch_context.launch_args.append(new_launch_args)
 


### PR DESCRIPTION
## Changelog Description
Previously opening of `Workfiles` app was controlled by old env var in Applications addon, now it should be configured by Tools > Workfiles Settings which are more granular.

! This changes default state of opening Workfiles app to NOT OPEN them (unless updated in `ayon+settings://core/tools/Workfiles/open_workfile_tool_on_startup`)

## Testing notes:
1. remove obsolete `AVALON_PHOTOSHOP_WORKFILES_ON_LAUNCH` line in `ayon+settings://applications/applications/photoshop`
<img width="1365" height="363" alt="image" src="https://github.com/user-attachments/assets/d024c5fc-f7ff-4eb2-acc0-819d70f04770" />

2.  experiment with `ayon+settings://core/tools/Workfiles/open_workfile_tool_on_startup`