### PR TITLE
Publish: Collect workfile instance plugin

### DIFF
--- a/client/ayon_photoshop/plugins/publish/collect_workfile.py
+++ b/client/ayon_photoshop/plugins/publish/collect_workfile.py
@@ -2,29 +2,27 @@ import os
 import pyblish.api
 
 
-class CollectWorkfile(pyblish.api.ContextPlugin):
+class CollectWorkfile(pyblish.api.InstancePlugin):
     """Collect current script for publish."""
 
     order = pyblish.api.CollectorOrder + 0.1
     label = "Collect Workfile"
     hosts = ["photoshop"]
+    families = ["workfile"]
 
     default_variant = "Main"
 
-    def process(self, context):
-        for instance in context:
-            if instance.data["productType"] == "workfile":
-                file_path = context.data["currentFile"]
-                _, ext = os.path.splitext(file_path)
-                staging_dir = os.path.dirname(file_path)
-                base_name = os.path.basename(file_path)
+    def process(self, instance):
+        file_path = context.data["currentFile"]
+        _, ext = os.path.splitext(file_path)
+        staging_dir = os.path.dirname(file_path)
+        base_name = os.path.basename(file_path)
 
-                # creating representation
-                _, ext = os.path.splitext(file_path)
-                instance.data["representations"].append({
-                    "name": ext[1:],
-                    "ext": ext[1:],
-                    "files": base_name,
-                    "stagingDir": staging_dir,
-                })
-                return
+        # creating representation
+        _, ext = os.path.splitext(file_path)
+        instance.data["representations"].append({
+            "name": ext[1:],
+            "ext": ext[1:],
+            "files": base_name,
+            "stagingDir": staging_dir,
+        })


### PR DESCRIPTION
## Changelog Description
Changed Collect Workfile to instance plugin.

## Additional review information
There is no reason to have this plugin as context plugin.

## Testing notes:
1. Workfile can be published without any issues.
