### PR TITLE
Create: Use kwargs to call product name functions

### DIFF
--- a/client/ayon_photoshop/plugins/create/create_flatten_image.py
+++ b/client/ayon_photoshop/plugins/create/create_flatten_image.py
@@ -132,7 +132,8 @@ class AutoImageCreator(PSAutoCreator):
         task_entity,
         variant,
         host_name=None,
-        instance=None
+        instance=None,
+        project_entity=None,
     ):
         if host_name is None:
             host_name = self.create_context.host_name
@@ -145,12 +146,13 @@ class AutoImageCreator(PSAutoCreator):
         dynamic_data = prepare_template_data({"layer": "{layer}"})
 
         product_name = get_product_name(
-            project_name,
-            task_name,
-            task_type,
-            host_name,
-            self.product_type,
-            variant,
-            dynamic_data=dynamic_data
+            project_name=project_name,
+            task_name=task_name,
+            task_type=task_type,
+            host_name=host_name,
+            product_type=self.product_type,
+            variant=variant,
+            dynamic_data=dynamic_data,
+            project_entity=project_entity,
         )
         return clean_product_name(product_name)

--- a/client/ayon_photoshop/plugins/publish/collect_auto_image.py
+++ b/client/ayon_photoshop/plugins/publish/collect_auto_image.py
@@ -81,12 +81,12 @@ class CollectAutoImage(pyblish.api.ContextPlugin):
             variant = context.data.get("variant") or variants[0]
 
             product_name = get_product_name(
-                project_name,
-                task_name,
-                task_type,
-                host_name,
-                product_type,
-                variant,
+                project_name=project_name,
+                task_name=task_name,
+                task_type=task_type,
+                host_name=host_name,
+                product_type=product_type,
+                variant=variant,
             )
 
             instance = context.create_instance(product_name)

--- a/client/ayon_photoshop/plugins/publish/collect_auto_review.py
+++ b/client/ayon_photoshop/plugins/publish/collect_auto_review.py
@@ -71,12 +71,12 @@ class CollectAutoReview(pyblish.api.ContextPlugin):
             task_type = task_entity["taskType"]
 
         product_name = get_product_name(
-            project_name,
-            task_name,
-            task_type,
-            host_name,
-            product_type,
-            variant,
+            project_name=project_name,
+            task_name=task_name,
+            task_type=task_type,
+            host_name=host_name,
+            product_type=product_type,
+            variant=variant,
             project_settings=proj_settings
         )
 

--- a/client/ayon_photoshop/plugins/publish/collect_auto_workfile.py
+++ b/client/ayon_photoshop/plugins/publish/collect_auto_workfile.py
@@ -76,12 +76,12 @@ class CollectAutoWorkfile(pyblish.api.ContextPlugin):
             task_type = task_entity["taskType"]
 
         product_name = get_product_name(
-            project_name,
-            task_name,
-            task_type,
-            host_name,
-            product_type,
-            variant,
+            project_name=project_name,
+            task_name=task_name,
+            task_type=task_type,
+            host_name=host_name,
+            product_type=product_type,
+            variant=variant,
             project_settings=proj_settings
         )
 


### PR DESCRIPTION
## Changelog Description
Use kwargs to call product name functions and use cached data to call them if possible.

## Additional review information
This is preparation for future change in `get_product_name` functionality and update of already added change in `get_product_name` method.

## Testing notes:
1. Product names are calculated correctly.
