### PR TITLE
Bugfix: Opening direct workfile from Launcher

### DIFF
--- a/client/ayon_photoshop/hooks/pre_launch_args.py
+++ b/client/ayon_photoshop/hooks/pre_launch_args.py
@@ -46,8 +46,8 @@ class PhotoshopPrelaunchHook(PreLaunchHook):
     Hook add python executable and script path to Photoshop implementation
     before Photoshop executable and add last workfile path to launch arguments.
 
-    Existence of last workfile is checked. If workfile does not exists tries
-    to copy templated workfile from predefined path.
+    Last workfile path would be added to self.launch_context.launch_args by
+    global `pre_add_last_workfile_arg`.
     """
     app_groups = {"photoshop"}
 


### PR DESCRIPTION
## Changelog Description
This solves an issue when Artist opened Workfile directly by selecting one in new right pane in Launcher. Publishing was then failing because file couldn't be saved.

## Additional review information
Problem seems to be in slashes in workfile path. 

## Testing notes:
1. select Workfile in right pane in Launcher
2. opened workfile tab in PS should contain only file name and not whole path
3. publish shouldn't fail