### PR TITLE
Create: Use args kwargs for product name and dynamic data

### DIFF
--- a/client/ayon_photoshop/lib.py
+++ b/client/ayon_photoshop/lib.py
@@ -58,11 +58,11 @@ class PSAutoCreator(AutoCreator):
                 project_name, folder_entity["id"], task_name
             )
             product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                self.default_variant,
-                host_name,
+                project_name=project_name,
+                folder_entity=folder_entity,
+                task_entity=task_entity,
+                variant=self.default_variant,
+                host_name=host_name,
             )
             data = {
                 "folderPath": folder_path,
@@ -99,11 +99,11 @@ class PSAutoCreator(AutoCreator):
                 project_name, folder_entity["id"], task_name
             )
             product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                self.default_variant,
-                host_name,
+                project_name=project_name,
+                folder_entity=folder_entity,
+                task_entity=task_entity,
+                variant=self.default_variant,
+                host_name=host_name,
             )
             existing_instance["folderPath"] = folder_path
             existing_instance["task"] = task_name

--- a/client/ayon_photoshop/plugins/create/create_flatten_image.py
+++ b/client/ayon_photoshop/plugins/create/create_flatten_image.py
@@ -45,11 +45,11 @@ class AutoImageCreator(PSAutoCreator):
 
         if existing_instance is None:
             product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                self.default_variant,
-                host_name,
+                project_name=project_name,
+                folder_entity=folder_entity,
+                task_entity=task_entity,
+                variant=self.default_variant,
+                host_name=host_name,
             )
 
             data = {
@@ -75,11 +75,11 @@ class AutoImageCreator(PSAutoCreator):
             or existing_instance["task"] != task_name
         ):
             product_name = self.get_product_name(
-                project_name,
-                folder_entity,
-                task_entity,
-                self.default_variant,
-                host_name,
+                project_name=project_name,
+                folder_entity=folder_entity,
+                task_entity=task_entity,
+                variant=self.default_variant,
+                host_name=host_name,
             )
             existing_instance["folderPath"] = folder_path
             existing_instance["task"] = task_name


### PR DESCRIPTION
## Changelog Description
Use args and kwargs for product name related methods.

## Additional review information
The args and kwargs are not used for the functionality of the methods, so it is safe to don't explicitly name them. It is a preaparation for https://github.com/ynput/ayon-core/pull/1647 .

## Testing notes:
1. Product names are created correctly with current core and with the PR.