### PR TITLE
Chore: Support product base type in get_versioning_start signature

### DIFF
--- a/client/ayon_photoshop/plugins/publish/collect_published_version.py
+++ b/client/ayon_photoshop/plugins/publish/collect_published_version.py
@@ -35,6 +35,7 @@ class CollectPublishedVersion(pyblish.api.ContextPlugin):
         for instance in context:
             product_base_type = instance.data.get("productBaseType")
             if not product_base_type:
+                # Backwards compatibility
                 product_base_type = instance.data["productType"]
             if product_base_type == "workfile":
                 workfile_product_name = instance.data["productName"]


### PR DESCRIPTION
## Changelog Description
Pass `product_base_type` and `product_type` to `get_versioning_start`.

## Additional review information
This actually adds product base type filtering and is also adding forwards compatibility for `product_base_type` argument in  https://github.com/ynput/ayon-core/pull/1667 .

## Testing notes:
1. The function work with new and old signature.
