### PR TITLE
Chore: Support product base type in get_versioning_start signature vol 2

### DIFF
--- a/client/ayon_photoshop/plugins/publish/collect_published_version.py
+++ b/client/ayon_photoshop/plugins/publish/collect_published_version.py
@@ -60,16 +60,14 @@ class CollectPublishedVersion(pyblish.api.ContextPlugin):
                 project_name=project_name,
                 host_name="photoshop",
                 product_base_type="workfile",
-                product_type="workfile",
                 task_name=context.data["task"],
                 task_type=context.data["taskType"],
-                project_settings=context.data["project_settings"]
-
+                project_settings=context.data["project_settings"],
             )
             if not is_func_signature_supported(
                 get_versioning_start, **kwargs
             ):
-                kwargs.pop("poduct_base_type")
+                kwargs["product_type"] = kwargs.pop("poduct_base_type")
             version_int = get_versioning_start(**kwargs)
 
         self.log.debug(f"Setting {version_int} to context.")


### PR DESCRIPTION
## Changelog Description
Pass only product base type or product type, not both.

## Additional review information
Extended variant of https://github.com/ynput/ayon-photoshop/pull/62 . Do not pass both product base type and product type, instead pass only one of them.

## Testing notes:
1. Work with current ayon-core and new ayon-core with https://github.com/ynput/ayon-core/pull/1667 .
