### PR TITLE
Add architecture to photoshop launch arguments

### DIFF
--- a/client/ayon_photoshop/api/launch_logic.py
+++ b/client/ayon_photoshop/api/launch_logic.py
@@ -1,7 +1,9 @@
-import os
-import subprocess
-import collections
 import asyncio
+import collections
+import os
+import platform
+import subprocess
+import sys
 
 from wsrpc_aiohttp import (
     WebSocketRoute,
@@ -29,7 +31,6 @@ from .webserver import WebServerTool
 from .ws_stub import PhotoshopServerStub
 
 log = Logger.get_logger(__name__)
-
 
 console_window = None
 
@@ -297,14 +298,46 @@ class ProcessLauncher(QtCore.QObject):
             return
         self.log.info("Starting host process")
         try:
+            args = list(self._subprocess_args)
+            if platform.system().lower() == "darwin":
+                exe_arches = self._macos_get_arches(args[0])
+                current_arches = set(self._macos_get_arches(sys.executable))
+                # Define architecture of the executable if is not the same as
+                #   current process architecture
+                if (
+                    exe_arches
+                    and not current_arches.intersection(set(exe_arches))
+                ):
+                    arch = exe_arches[0]
+                    args.insert(0, "arch")
+                    args.insert(1, f"-{arch}")
+                    self.log.info(
+                        f"Using arch '{arch}' to launch host process"
+                    )
+
             self._process = subprocess.Popen(
-                self._subprocess_args,
+                args,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL
             )
         except Exception:
             self.log.info("exce", exc_info=True)
             self.exit()
+
+    def _macos_get_arches(self, executable_path: str) -> list[str]:
+        try:
+            output = subprocess.check_output(
+                ["lipo", "-archs", executable_path],
+                text=True
+            ).strip()
+        except Exception:
+            self.log.warning(
+                "Failed to get architectures of an executable:"
+                f" {executable_path}",
+                exc_info=True
+            )
+            return []
+        return list(output.split())
 
 
 def show_script_editor():

--- a/client/ayon_photoshop/api/launch_logic.py
+++ b/client/ayon_photoshop/api/launch_logic.py
@@ -300,20 +300,8 @@ class ProcessLauncher(QtCore.QObject):
         try:
             args = list(self._subprocess_args)
             if platform.system().lower() == "darwin":
-                exe_arches = self._macos_get_arches(args[0])
-                current_arches = set(self._macos_get_arches(sys.executable))
-                # Define architecture of the executable if is not the same as
-                #   current process architecture
-                if (
-                    exe_arches
-                    and not current_arches.intersection(set(exe_arches))
-                ):
-                    arch = exe_arches[0]
-                    args.insert(0, "arch")
-                    args.insert(1, f"-{arch}")
-                    self.log.info(
-                        f"Using arch '{arch}' to launch host process"
-                    )
+                args.insert(0, "arch")
+                args.insert(1, "-x86_64")
 
             self._process = subprocess.Popen(
                 args,
@@ -323,21 +311,6 @@ class ProcessLauncher(QtCore.QObject):
         except Exception:
             self.log.info("exce", exc_info=True)
             self.exit()
-
-    def _macos_get_arches(self, executable_path: str) -> list[str]:
-        try:
-            output = subprocess.check_output(
-                ["lipo", "-archs", executable_path],
-                text=True
-            ).strip()
-        except Exception:
-            self.log.warning(
-                "Failed to get architectures of an executable:"
-                f" {executable_path}",
-                exc_info=True
-            )
-            return []
-        return list(output.split())
 
 
 def show_script_editor():

--- a/client/ayon_photoshop/api/launch_logic.py
+++ b/client/ayon_photoshop/api/launch_logic.py
@@ -3,7 +3,6 @@ import collections
 import os
 import platform
 import subprocess
-import sys
 
 from wsrpc_aiohttp import (
     WebSocketRoute,


### PR DESCRIPTION
## Changelog Description
Add architecture arguments on macos.

## Additional review information
AYON photoshop plugin requires to be using x86_64 architecture.

## Testing notes:
1. Photoshop (using `x86_64`) can be launched using AYON launcher build with arm64 (1.5.4).

Resolves https://github.com/ynput/ayon-photoshop/issues/86