### PR TITLE
Extract layers workflow: Support for psb format and marked optional

### DIFF
--- a/client/ayon_photoshop/api/ws_stub.py
+++ b/client/ayon_photoshop/api/ws_stub.py
@@ -427,7 +427,7 @@ class PhotoshopServerStub:
             # Save and close the duplicated document
             self.saveAs(
                 image_path=str(path),
-                ext=extension,
+                ext=path.suffix[1:],
                 as_copy=False
             )
             self.close_document(document_id)

--- a/client/ayon_photoshop/api/ws_stub.py
+++ b/client/ayon_photoshop/api/ws_stub.py
@@ -403,7 +403,7 @@ class PhotoshopServerStub:
         )
 
     @contextmanager
-    def duplicate_document(self, path: str, extension: str):
+    def duplicate_document(self, path: str):
         """Duplicate active document and save it to path.
 
         Can be used as context manager:

--- a/client/ayon_photoshop/api/ws_stub.py
+++ b/client/ayon_photoshop/api/ws_stub.py
@@ -403,7 +403,7 @@ class PhotoshopServerStub:
         )
 
     @contextmanager
-    def duplicate_document(self, path: str):
+    def duplicate_document(self, path: str, extension: str):
         """Duplicate active document and save it to path.
 
         Can be used as context manager:
@@ -414,6 +414,7 @@ class PhotoshopServerStub:
 
         Args:
             path (str): file path to save duplicated document
+            extension (str): file extension for duplicated document (e.g. "psd")
         """
         try:
             path = Path(path)
@@ -427,7 +428,7 @@ class PhotoshopServerStub:
             # Save and close the duplicated document
             self.saveAs(
                 image_path=str(path),
-                ext=path.suffix[1:],
+                ext=extension,
                 as_copy=False
             )
             self.close_document(document_id)

--- a/client/ayon_photoshop/api/ws_stub.py
+++ b/client/ayon_photoshop/api/ws_stub.py
@@ -414,7 +414,6 @@ class PhotoshopServerStub:
 
         Args:
             path (str): file path to save duplicated document
-            extension (str): file extension for duplicated document (e.g. "psd")
         """
         try:
             path = Path(path)

--- a/client/ayon_photoshop/plugins/publish/extract_image.py
+++ b/client/ayon_photoshop/plugins/publish/extract_image.py
@@ -8,7 +8,8 @@ from ayon_photoshop import api as photoshop
 
 class ExtractImage(
     pyblish.api.ContextPlugin,
-    publish.ColormanagedPyblishPluginMixin
+    publish.ColormanagedPyblishPluginMixin,
+    publish.OptionalPyblishPluginMixin
 ):
     """Extract all layers (groups) marked for publish.
 
@@ -27,8 +28,11 @@ class ExtractImage(
     families = ["image", "background"]
     formats = ["png", "jpg", "tga", "exr"]
     settings_category = "photoshop"
+    optional = True
 
     def process(self, context):
+        if not self.is_active(context.data):
+            return
         # Filter instances
         filtered_instances = []
         for instance in context:

--- a/client/ayon_photoshop/plugins/publish/extract_image.py
+++ b/client/ayon_photoshop/plugins/publish/extract_image.py
@@ -28,7 +28,7 @@ class ExtractImage(
     families = ["image", "background"]
     formats = ["png", "jpg", "tga", "exr"]
     settings_category = "photoshop"
-    optional = True
+    optional = False
 
     def process(self, context):
         if not self.is_active(context.data):

--- a/client/ayon_photoshop/plugins/publish/extract_image.py
+++ b/client/ayon_photoshop/plugins/publish/extract_image.py
@@ -1,9 +1,12 @@
 import os
+from typing import TYPE_CHECKING
 
 import pyblish.api
 from ayon_core.pipeline import publish
 from ayon_core.pipeline.colorspace import get_remapped_colorspace_from_native
 from ayon_photoshop import api as photoshop
+if TYPE_CHECKING:
+    from ayon_core.pipeline import CreateContext, CreatedInstance
 
 
 class ExtractImage(
@@ -31,10 +34,14 @@ class ExtractImage(
     optional = False
 
     def process(self, context):
-        if not self.is_active(context.data):
-            return
         # Filter instances
         filtered_instances = []
+        for instance in context:
+            if (
+                instance.data["productBaseType"] != "image"
+                or not self.is_active(instance.data)
+            ):
+                continue
         for instance in context:
             product_base_type = instance.data.get("productBaseType")
             if not product_base_type:
@@ -131,3 +138,15 @@ class ExtractImage(
         from ayon_core.pipeline.publish import get_instance_staging_dir
 
         return get_instance_staging_dir(instance)
+
+    @classmethod
+    def get_attr_defs_for_context(cls, create_context: "CreateContext"):
+        return []
+
+    @classmethod
+    def get_attr_defs_for_instance(
+        cls, create_context: "CreateContext", instance: "CreatedInstance"
+    ):
+        if instance.product_base_type != "image":
+            return []
+        return cls.get_attribute_defs()

--- a/client/ayon_photoshop/plugins/publish/extract_layers.py
+++ b/client/ayon_photoshop/plugins/publish/extract_layers.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 
 from ayon_core.pipeline import publish
-from ayon_core.lib import EnumDef
 from ayon_core.pipeline.colorspace import get_remapped_colorspace_from_native
 from ayon_core.pipeline.publish import get_instance_staging_dir
 from ayon_photoshop import api as photoshop

--- a/client/ayon_photoshop/plugins/publish/extract_layers.py
+++ b/client/ayon_photoshop/plugins/publish/extract_layers.py
@@ -46,10 +46,10 @@ class ExtractLayers(
 
         filepath = Path(
             get_instance_staging_dir(instance),
-            f"{filename_without_ext}.{self.extension}"
+            filename
         )
         self.log.info(f"Duplicating document to staging directory: {filepath}")
-        with ps_stub.duplicate_document(filepath):
+        with ps_stub.duplicate_document(filepath, self.extension):
             # Delete all layers except the instance layerset
             layer = instance.data.get("layer")
             ps_stub.delete_all_layers(
@@ -73,7 +73,7 @@ class ExtractLayers(
         representation = {
             "name": self.extension,
             "ext": self.extension,
-            "files": filepath.name,
+            "files": f"{filename_without_ext}.{self.extension}",
             "stagingDir": filepath.parent,
         }
         # inject colorspace data

--- a/client/ayon_photoshop/plugins/publish/extract_layers.py
+++ b/client/ayon_photoshop/plugins/publish/extract_layers.py
@@ -90,7 +90,7 @@ class ExtractLayers(
         return [
             EnumDef(
                 "extension",
-                label="layer extension",
+                label="Layer extension",
                 items=["psb", "psd"],
                 default=cls.extension
             ),

--- a/client/ayon_photoshop/plugins/publish/extract_layers.py
+++ b/client/ayon_photoshop/plugins/publish/extract_layers.py
@@ -20,7 +20,7 @@ class ExtractLayers(
     order = publish.Extractor.order  # Must be after ExtractImage
     hosts = ["photoshop"]
     families = ["image"]
-    optional = True
+    optional = False
     merge_layersets = False
     extension = "psd"
 

--- a/client/ayon_photoshop/plugins/publish/extract_layers.py
+++ b/client/ayon_photoshop/plugins/publish/extract_layers.py
@@ -44,13 +44,12 @@ class ExtractLayers(
         # Duplicate the document to the staging directory
         filename = ps_stub.get_active_document_name()
         filename_without_ext = os.path.splitext(filename)[0]
-
         filepath = Path(
             get_instance_staging_dir(instance),
-            filename
+            f"{filename_without_ext}.{self.extension}"
         )
         self.log.info(f"Duplicating document to staging directory: {filepath}")
-        with ps_stub.duplicate_document(filepath, self.extension):
+        with ps_stub.duplicate_document(filepath):
             # Delete all layers except the instance layerset
             layer = instance.data.get("layer")
             ps_stub.delete_all_layers(
@@ -74,7 +73,7 @@ class ExtractLayers(
         representation = {
             "name": self.extension,
             "ext": self.extension,
-            "files": f"{filename_without_ext}.{self.extension}",
+            "files": filepath.name,
             "stagingDir": filepath.parent,
         }
         # inject colorspace data

--- a/client/ayon_photoshop/plugins/publish/extract_layers.py
+++ b/client/ayon_photoshop/plugins/publish/extract_layers.py
@@ -43,7 +43,7 @@ class ExtractLayers(
         # Duplicate the document to the staging directory
         filename = ps_stub.get_active_document_name()
         basename = os.path.splitext(filename)[0]
-        filename = f"{basename}.{self.extension}
+        filename = f"{basename}.{self.extension}"
         filepath = Path(
             get_instance_staging_dir(instance),
             f"{filename_without_ext}.{self.extension}"

--- a/client/ayon_photoshop/plugins/publish/extract_layers.py
+++ b/client/ayon_photoshop/plugins/publish/extract_layers.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 from ayon_core.pipeline import publish
+from ayon_core.lib import EnumDef
 from ayon_core.pipeline.colorspace import get_remapped_colorspace_from_native
 from ayon_core.pipeline.publish import get_instance_staging_dir
 from ayon_photoshop import api as photoshop

--- a/client/ayon_photoshop/plugins/publish/extract_layers.py
+++ b/client/ayon_photoshop/plugins/publish/extract_layers.py
@@ -8,7 +8,8 @@ from ayon_photoshop import api as photoshop
 
 class ExtractLayers(
     publish.Extractor,
-    publish.ColormanagedPyblishPluginMixin
+    publish.ColormanagedPyblishPluginMixin,
+    publish.OptionalPyblishPluginMixin
 ):
     """Export layers within the instance layerset to a PSD file.
 
@@ -19,9 +20,13 @@ class ExtractLayers(
     order = publish.Extractor.order  # Must be after ExtractImage
     hosts = ["photoshop"]
     families = ["image"]
+    optional = True
     merge_layersets = False
+    extension = "psd"
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
         ps_stub = photoshop.stub()
         native_colorspace = ps_stub.get_color_profile_name()
         self.log.info(f"Document colorspace profile: {native_colorspace}")
@@ -64,8 +69,8 @@ class ExtractLayers(
         instance.data["stagingDir"] = filepath.parent
         representations = instance.data.setdefault("representations", [])
         representation = {
-            "name": "psd",
-            "ext": "psd",
+            "name": self.extension,
+            "ext": self.extension,
             "files": filepath.name,
             "stagingDir": filepath.parent,
         }

--- a/client/ayon_photoshop/plugins/publish/extract_layers.py
+++ b/client/ayon_photoshop/plugins/publish/extract_layers.py
@@ -46,7 +46,7 @@ class ExtractLayers(
         filename = f"{basename}.{self.extension}"
         filepath = Path(
             get_instance_staging_dir(instance),
-            f"{filename_without_ext}.{self.extension}"
+            filename
         )
         self.log.info(f"Duplicating document to staging directory: {filepath}")
         with ps_stub.duplicate_document(filepath):
@@ -81,5 +81,5 @@ class ExtractLayers(
             representation, instance.context,
             colorspace=ayon_colorspace
         )
-        self.log.debug(f"Rrepresentation: {representation}")
+        self.log.debug(f"Representation: {representation}")
         representations.append(representation)

--- a/client/ayon_photoshop/plugins/publish/extract_layers.py
+++ b/client/ayon_photoshop/plugins/publish/extract_layers.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from ayon_core.pipeline import publish
@@ -28,8 +29,6 @@ class ExtractLayers(
     def process(self, instance):
         if not self.is_active(instance.data):
             return
-        attr_values = self.get_attr_values_from_data(instance.data)
-        layer_extension = attr_values.get("extension", self.extension)
         ps_stub = photoshop.stub()
         native_colorspace = ps_stub.get_color_profile_name()
         self.log.info(f"Document colorspace profile: {native_colorspace}")
@@ -43,14 +42,15 @@ class ExtractLayers(
         )
         self.log.debug(f"ayon_colorspace: {ayon_colorspace}")
         # Duplicate the document to the staging directory
+        filename = ps_stub.get_active_document_name()
+        filename_without_ext = os.path.splitext(filename)[0]
+
         filepath = Path(
             get_instance_staging_dir(instance),
-            ps_stub.get_active_document_name()
+            f"{filename_without_ext}.{self.extension}"
         )
         self.log.info(f"Duplicating document to staging directory: {filepath}")
-        with ps_stub.duplicate_document(
-            filepath
-        ):
+        with ps_stub.duplicate_document(filepath):
             # Delete all layers except the instance layerset
             layer = instance.data.get("layer")
             ps_stub.delete_all_layers(
@@ -72,8 +72,8 @@ class ExtractLayers(
         instance.data["stagingDir"] = filepath.parent
         representations = instance.data.setdefault("representations", [])
         representation = {
-            "name": layer_extension,
-            "ext": layer_extension,
+            "name": self.extension,
+            "ext": self.extension,
             "files": filepath.name,
             "stagingDir": filepath.parent,
         }
@@ -84,14 +84,3 @@ class ExtractLayers(
         )
         self.log.debug(f"Rrepresentation: {representation}")
         representations.append(representation)
-
-    @classmethod
-    def get_attribute_defs(cls):
-        return super().get_attribute_defs() + [
-            EnumDef(
-                "extension",
-                label="layer extension",
-                items=["psb", "psd"],
-                default=cls.extension
-            ),
-        ]

--- a/client/ayon_photoshop/plugins/publish/extract_layers.py
+++ b/client/ayon_photoshop/plugins/publish/extract_layers.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from ayon_core.pipeline import publish
+from ayon_core.lib import EnumDef
 from ayon_core.pipeline.colorspace import get_remapped_colorspace_from_native
 from ayon_core.pipeline.publish import get_instance_staging_dir
 from ayon_photoshop import api as photoshop
@@ -27,6 +28,8 @@ class ExtractLayers(
     def process(self, instance):
         if not self.is_active(instance.data):
             return
+        attr_values = self.get_attr_values_from_data(instance.data)
+        layer_extension = attr_values.get("extension", self.extension)
         ps_stub = photoshop.stub()
         native_colorspace = ps_stub.get_color_profile_name()
         self.log.info(f"Document colorspace profile: {native_colorspace}")
@@ -69,8 +72,8 @@ class ExtractLayers(
         instance.data["stagingDir"] = filepath.parent
         representations = instance.data.setdefault("representations", [])
         representation = {
-            "name": self.extension,
-            "ext": self.extension,
+            "name": layer_extension,
+            "ext": layer_extension,
             "files": filepath.name,
             "stagingDir": filepath.parent,
         }
@@ -81,3 +84,14 @@ class ExtractLayers(
         )
         self.log.debug(f"Rrepresentation: {representation}")
         representations.append(representation)
+
+    @classmethod
+    def get_attribute_defs(cls):
+        return [
+            EnumDef(
+                "extension",
+                label="layer extension",
+                items=["psb", "psd"],
+                default=cls.extension
+            ),
+        ]

--- a/client/ayon_photoshop/plugins/publish/extract_layers.py
+++ b/client/ayon_photoshop/plugins/publish/extract_layers.py
@@ -87,10 +87,10 @@ class ExtractLayers(
 
     @classmethod
     def get_attribute_defs(cls):
-        return [
+        return super().get_attribute_defs() + [
             EnumDef(
                 "extension",
-                label="Layer extension",
+                label="layer extension",
                 items=["psb", "psd"],
                 default=cls.extension
             ),

--- a/client/ayon_photoshop/plugins/publish/extract_layers.py
+++ b/client/ayon_photoshop/plugins/publish/extract_layers.py
@@ -42,7 +42,8 @@ class ExtractLayers(
         self.log.debug(f"ayon_colorspace: {ayon_colorspace}")
         # Duplicate the document to the staging directory
         filename = ps_stub.get_active_document_name()
-        filename_without_ext = os.path.splitext(filename)[0]
+        basename = os.path.splitext(filename)[0]
+        filename = f"{basename}.{self.extension}
         filepath = Path(
             get_instance_staging_dir(instance),
             f"{filename_without_ext}.{self.extension}"

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -154,7 +154,7 @@ class ExtractLayersPlugin(BaseSettingsModel):
     )
     extension: str = SettingsField(
         "psd",
-        title="Extracted layer extension",
+        title="Export extension",
         enum_resolver=lambda: extract_layer_ext_enum,
     )
 

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -238,7 +238,7 @@ DEFAULT_PUBLISH_SETTINGS = {
     },
     "ExtractImage": {
         "enabled": True,
-        "optional": True,
+        "optional": False,
         "formats": [
             "png",
             "jpg",

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -25,6 +25,11 @@ extract_image_ext_enum = [
     {"value": "exr", "label": "exr"},
 ]
 
+extract_layer_ext_enum = [
+    {"value": "psd", "label": "psd"},
+    {"value": "psb", "label": "psb"},
+]
+
 color_mode_enum = [
     {"value": "RGB", "label": "RGB"},
     {"value": "CMYK", "label": "CMYK"},
@@ -122,7 +127,8 @@ class ValidateNamingPlugin(BaseSettingsModel):
 
 class ExtractImagePlugin(BaseSettingsModel):
     """Extracts image products and representations per published instance"""
-
+    enabled: bool = SettingsField(True, title="Enabled")
+    optional: bool = SettingsField(True, title="Optional")
     formats: list[str] = SettingsField(
         title="Extract Formats",
         default_factory=list,
@@ -140,10 +146,16 @@ class ExtractSourceReviewPlugin(BaseSettingsModel):
 class ExtractLayersPlugin(BaseSettingsModel):
     """Export layers within the instance layerset to a PSD file."""
     enabled: bool = SettingsField(False, title="Enabled")
+    optional: bool = SettingsField(True, title="Optional")
     merge_layersets: bool = SettingsField(
         False,
         title="Merge Layersets",
         description="Merge all layersets within the instance set.",
+    )
+    extension: str = SettingsField(
+        "psd",
+        title="Extracted layer extension",
+        enum_resolver=lambda: extract_layer_ext_enum,
     )
 
 
@@ -225,6 +237,8 @@ DEFAULT_PUBLISH_SETTINGS = {
         "replace_char": "_"
     },
     "ExtractImage": {
+        "enabled": True,
+        "optional": True,
         "formats": [
             "png",
             "jpg",
@@ -235,7 +249,9 @@ DEFAULT_PUBLISH_SETTINGS = {
     },
     "ExtractLayers": {
         "enabled": False,
-        "merge_layersets": False
+        "optional": True,
+        "merge_layersets": False,
+        "extension": "psd",
     },
     "ValidateDocumentSettings": {
         "enabled": False,

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -249,7 +249,7 @@ DEFAULT_PUBLISH_SETTINGS = {
     },
     "ExtractLayers": {
         "enabled": False,
-        "optional": True,
+        "optional": False,
         "merge_layersets": False,
         "extension": "psd",
     },

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -146,7 +146,7 @@ class ExtractSourceReviewPlugin(BaseSettingsModel):
 class ExtractLayersPlugin(BaseSettingsModel):
     """Export layers within the instance layerset to a PSD file."""
     enabled: bool = SettingsField(False, title="Enabled")
-    optional: bool = SettingsField(True, title="Optional")
+    optional: bool = SettingsField(False, title="Optional")
     merge_layersets: bool = SettingsField(
         False,
         title="Merge Layersets",

--- a/server/settings/publish_plugins.py
+++ b/server/settings/publish_plugins.py
@@ -128,7 +128,7 @@ class ValidateNamingPlugin(BaseSettingsModel):
 class ExtractImagePlugin(BaseSettingsModel):
     """Extracts image products and representations per published instance"""
     enabled: bool = SettingsField(True, title="Enabled")
-    optional: bool = SettingsField(True, title="Optional")
+    optional: bool = SettingsField(False, title="Optional")
     formats: list[str] = SettingsField(
         title="Extract Formats",
         default_factory=list,


### PR DESCRIPTION

## Changelog Description
This PR is to add support for psb format in extract layers and allows it to be optional. This PR also allowed extract image to be optional too so users can disable that if they just want to extract layers in psd/psb format.

## Additional review information
Fix https://github.com/ynput/ayon-photoshop/issues/89
Try to publish with psb format to ensure that the files aren't corrupted in any case.

## Testing notes:
1. Tweak `ayon+settings://photoshop/publish/ExtractLayers` settings (extensions and you can choose it to be optional in the publisher etc.). 
2. You can now also turn on/off  `ayon+settings://photoshop/publish/ExtractImages` and allows it to be optional extractor in the publisher
3. Launch PS
4. Create Instance with separate instances for each layer.
5. Publish
