### PR TITLE
Add settings for default workfile extensions

### DIFF
--- a/client/ayon_photoshop/api/pipeline.py
+++ b/client/ayon_photoshop/api/pipeline.py
@@ -55,9 +55,9 @@ class PhotoshopHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_creator_plugin_path(CREATE_PATH)
 
         register_event_callback("application.launched", on_application_launch)
-        self.workfile_extensions = self.get_default_workfile_extension()
+        self._get_default_workfile_extension()
 
-    def get_default_workfile_extension(self) -> list[str]:
+    def _get_default_workfile_extension(self) -> list[str]:
         """Get the default workfile extension for the current project.
 
         Returns:
@@ -67,10 +67,9 @@ class PhotoshopHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         project_name = get_current_project_name()
         settings = get_project_settings(project_name)
         default_workfile_extension = settings["photoshop"].get("default_workfile_extension", ".psd")
-        return sorted(
-            self.workfile_extensions,
-            key=lambda x: x != default_workfile_extension
-        )
+        if self.workfile_extensions[0] != default_workfile_extension:
+            self.workfile_extensions.remove(default_workfile_extension)
+            self.workfile_extensions.insert(0, default_workfile_extension)
 
     def work_root(self, session):
         return os.path.normpath(session["AYON_WORKDIR"]).replace("\\", "/")

--- a/client/ayon_photoshop/api/pipeline.py
+++ b/client/ayon_photoshop/api/pipeline.py
@@ -55,9 +55,9 @@ class PhotoshopHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_creator_plugin_path(CREATE_PATH)
 
         register_event_callback("application.launched", on_application_launch)
-        self._get_default_workfile_extension()
+        self._set_default_workfile_extension()
 
-    def _get_default_workfile_extension(self) -> list[str]:
+    def _set_default_workfile_extension(self) -> list[str]:
         """Get the default workfile extension for the current project.
 
         Returns:

--- a/client/ayon_photoshop/api/pipeline.py
+++ b/client/ayon_photoshop/api/pipeline.py
@@ -39,6 +39,7 @@ INVENTORY_PATH = os.path.join(PLUGINS_DIR, "inventory")
 
 class PhotoshopHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     name = "photoshop"
+    workfile_extensions = [".psd", ".psb"]
 
     def install(self):
         """Install Photoshop-specific functionality needed for integration.
@@ -54,6 +55,9 @@ class PhotoshopHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_creator_plugin_path(CREATE_PATH)
 
         register_event_callback("application.launched", on_application_launch)
+        self.workfile_extensions = _get_default_workfile_extension(
+            self.workfile_extensions
+        )
 
     def work_root(self, session):
         return os.path.normpath(session["AYON_WORKDIR"]).replace("\\", "/")
@@ -84,7 +88,7 @@ class PhotoshopHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return False
 
     def get_workfile_extensions(self):
-        return get_default_workfile_extension()
+        return self.workfile_extensions
 
     def get_containers(self):
         return ls()
@@ -284,13 +288,13 @@ def cache_and_get_instances(creator):
     return creator.collection_shared_data[shared_key]
 
 
-def get_default_workfile_extension() -> list[str]:
+def _get_default_workfile_extension(workfile_extension_list: list[str]) -> list[str]:
     """Get the default workfile extension for the current project.
 
     Returns:
         list[str]: list of workfile extensions
     """
-    workfile_extension_list = [".psd", ".psb"]
+
     project_name = get_current_project_name()
     settings = get_project_settings(project_name)
     default_workfile_extension = settings["photoshop"].get("default_workfile_extension", ".psd")

--- a/client/ayon_photoshop/api/pipeline.py
+++ b/client/ayon_photoshop/api/pipeline.py
@@ -57,12 +57,8 @@ class PhotoshopHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_event_callback("application.launched", on_application_launch)
         self._set_default_workfile_extension()
 
-    def _set_default_workfile_extension(self) -> list[str]:
-        """Get the default workfile extension for the current project.
-
-        Returns:
-            list[str]: list of workfile extensions
-        """
+    def _set_default_workfile_extension(self) -> None:
+        """Get the default workfile extension for the current project."""
 
         project_name = get_current_project_name()
         settings = get_project_settings(project_name)

--- a/client/ayon_photoshop/api/pipeline.py
+++ b/client/ayon_photoshop/api/pipeline.py
@@ -11,7 +11,9 @@ from ayon_core.pipeline import (
     AVALON_CONTAINER_ID,
     AYON_INSTANCE_ID,
     AVALON_INSTANCE_ID,
+    get_current_project_name,
 )
+from ayon_core.settings import get_project_settings
 
 from ayon_core.host import (
     HostBase,
@@ -82,7 +84,7 @@ class PhotoshopHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         return False
 
     def get_workfile_extensions(self):
-        return [".psd", ".psb"]
+        return get_default_workfile_extension()
 
     def get_containers(self):
         return ls()
@@ -280,3 +282,19 @@ def cache_and_get_instances(creator):
         creator.collection_shared_data[shared_key] = \
             creator.host.list_instances()
     return creator.collection_shared_data[shared_key]
+
+
+def get_default_workfile_extension() -> list[str]:
+    """Get the default workfile extension for the current project.
+
+    Returns:
+        list[str]: list of workfile extensions
+    """
+    workfile_extension_list = [".psd", ".psb"]
+    project_name = get_current_project_name()
+    settings = get_project_settings(project_name)
+    default_workfile_extension = settings["photoshop"].get("default_workfile_extension", ".psd")
+    return sorted(
+        workfile_extension_list,
+        key=lambda x: x != default_workfile_extension
+    )

--- a/client/ayon_photoshop/api/pipeline.py
+++ b/client/ayon_photoshop/api/pipeline.py
@@ -11,7 +11,6 @@ from ayon_core.pipeline import (
     AVALON_CONTAINER_ID,
     AYON_INSTANCE_ID,
     AVALON_INSTANCE_ID,
-    get_current_project_name,
 )
 from ayon_core.settings import get_project_settings
 
@@ -60,9 +59,9 @@ class PhotoshopHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
     def _set_default_workfile_extension(self) -> None:
         """Get the default workfile extension for the current project."""
 
-        project_name = get_current_project_name()
+        project_name = self.get_current_project_name()
         settings = get_project_settings(project_name)
-        default_workfile_extension = settings["photoshop"].get("default_workfile_extension", ".psd")
+        default_workfile_extension = settings["photoshop"]["default_workfile_extension"]
         if self.workfile_extensions[0] != default_workfile_extension:
             self.workfile_extensions.remove(default_workfile_extension)
             self.workfile_extensions.insert(0, default_workfile_extension)

--- a/client/ayon_photoshop/api/pipeline.py
+++ b/client/ayon_photoshop/api/pipeline.py
@@ -55,8 +55,21 @@ class PhotoshopHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         register_creator_plugin_path(CREATE_PATH)
 
         register_event_callback("application.launched", on_application_launch)
-        self.workfile_extensions = _get_default_workfile_extension(
-            self.workfile_extensions
+        self.workfile_extensions = self.get_default_workfile_extension()
+
+    def get_default_workfile_extension(self) -> list[str]:
+        """Get the default workfile extension for the current project.
+
+        Returns:
+            list[str]: list of workfile extensions
+        """
+
+        project_name = get_current_project_name()
+        settings = get_project_settings(project_name)
+        default_workfile_extension = settings["photoshop"].get("default_workfile_extension", ".psd")
+        return sorted(
+            self.workfile_extensions,
+            key=lambda x: x != default_workfile_extension
         )
 
     def work_root(self, session):
@@ -286,19 +299,3 @@ def cache_and_get_instances(creator):
         creator.collection_shared_data[shared_key] = \
             creator.host.list_instances()
     return creator.collection_shared_data[shared_key]
-
-
-def _get_default_workfile_extension(workfile_extension_list: list[str]) -> list[str]:
-    """Get the default workfile extension for the current project.
-
-    Returns:
-        list[str]: list of workfile extensions
-    """
-
-    project_name = get_current_project_name()
-    settings = get_project_settings(project_name)
-    default_workfile_extension = settings["photoshop"].get("default_workfile_extension", ".psd")
-    return sorted(
-        workfile_extension_list,
-        key=lambda x: x != default_workfile_extension
-    )

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -6,6 +6,12 @@ from .publish_plugins import PhotoshopPublishPlugins, DEFAULT_PUBLISH_SETTINGS
 from .workfile_builder import WorkfileBuilderPlugin
 
 
+default_workfile_extensions_enum = [
+    {"value": ".psd", "label": "psd"},
+    {"value": ".psb", "label": "psb"},
+]
+
+
 class PhotoshopSettings(BaseSettingsModel):
     """Photoshop Project Settings."""
 
@@ -13,6 +19,12 @@ class PhotoshopSettings(BaseSettingsModel):
         False,
         title="Install AYON Extension",
         description="Triggers pre-launch hook which installs extension."
+    )
+    default_workfile_extension: str = SettingsField(
+        ".psd",
+        title="Default workfile extension",
+        description="Default extension used when saving workfiles.",
+        enum_resolver=lambda: default_workfile_extensions_enum,
     )
 
     imageio: PhotoshopImageIOModel = SettingsField(
@@ -38,6 +50,7 @@ class PhotoshopSettings(BaseSettingsModel):
 
 DEFAULT_PHOTOSHOP_SETTING = {
     "auto_install_extension": True,
+    "default_workfile_extension": ".psd",
     "create": DEFAULT_CREATE_SETTINGS,
     "publish": DEFAULT_PUBLISH_SETTINGS,
     "workfile_builder": {


### PR DESCRIPTION
## Changelog Description
This PR is to add setting for default workfile extensions in ayon servers. User can choose and prioritize which extension they would like to save with workfile tool.

## Additional review information
Resolve https://github.com/ynput/ayon-photoshop/issues/90
Marked it as draft due to the ongoing discussion on the issue.

## Testing notes:
1. Choose your preferred setting in `ayon+settings://photoshop/default_workfile_extension`
2. Launch PS 
3. Click `workfile`
4. Save as -> the workfile extension should be `.psb`