### PR TITLE
Fix macOS Photoshop architecture selection

### DIFF
--- a/client/ayon_photoshop/api/launch_logic.py
+++ b/client/ayon_photoshop/api/launch_logic.py
@@ -3,6 +3,7 @@ import collections
 import os
 import platform
 import subprocess
+import sys
 
 from wsrpc_aiohttp import (
     WebSocketRoute,
@@ -26,6 +27,7 @@ from ayon_core.pipeline.template_data import get_template_data_with_names
 from ayon_core.tools.utils import host_tools
 from ayon_core.pipeline.context_tools import change_current_context
 
+from .launch_utils import get_macos_launch_args
 from .webserver import WebServerTool
 from .ws_stub import PhotoshopServerStub
 
@@ -299,8 +301,19 @@ class ProcessLauncher(QtCore.QObject):
         try:
             args = list(self._subprocess_args)
             if platform.system().lower() == "darwin":
-                args.insert(0, "arch")
-                args.insert(1, "-x86_64")
+                executable_arches = self._macos_get_arches(args[0])
+                process_arches = set(
+                    self._macos_get_arches(sys.executable)
+                )
+                args, arch = get_macos_launch_args(
+                    args,
+                    executable_arches,
+                    process_arches,
+                )
+                if arch:
+                    self.log.info(
+                        f"Using arch '{arch}' to launch host process"
+                    )
 
             self._process = subprocess.Popen(
                 args,
@@ -310,6 +323,21 @@ class ProcessLauncher(QtCore.QObject):
         except Exception:
             self.log.info("exce", exc_info=True)
             self.exit()
+
+    def _macos_get_arches(self, executable_path: str) -> list[str]:
+        try:
+            output = subprocess.check_output(
+                ["lipo", "-archs", executable_path],
+                text=True
+            ).strip()
+        except Exception:
+            self.log.warning(
+                "Failed to get architectures of an executable:"
+                f" {executable_path}",
+                exc_info=True
+            )
+            return []
+        return output.split()
 
 
 def show_script_editor():

--- a/client/ayon_photoshop/api/launch_utils.py
+++ b/client/ayon_photoshop/api/launch_utils.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+
+def get_macos_launch_args(
+    subprocess_args: list[str],
+    executable_arches: list[str],
+    process_arches: set[str],
+) -> tuple[list[str], Optional[str]]:
+    """Prepare launch arguments for a macOS executable."""
+    args = list(subprocess_args)
+    if (
+        executable_arches
+        and process_arches
+        and not process_arches.intersection(executable_arches)
+    ):
+        arch = executable_arches[0]
+        args[:0] = ["arch", f"-{arch}"]
+        return args, arch
+    return args, None

--- a/tests/test_launch_utils.py
+++ b/tests/test_launch_utils.py
@@ -1,0 +1,77 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+MODULE_PATH = (
+    Path(__file__).parents[1]
+    / "client"
+    / "ayon_photoshop"
+    / "api"
+    / "launch_utils.py"
+)
+SPEC = importlib.util.spec_from_file_location("launch_utils", MODULE_PATH)
+launch_utils = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(launch_utils)
+
+
+class GetMacosLaunchArgsTest(unittest.TestCase):
+    def test_keeps_native_arguments_for_universal_photoshop(self):
+        args, arch = launch_utils.get_macos_launch_args(
+            ["/Applications/Adobe Photoshop/Photoshop"],
+            ["x86_64", "arm64"],
+            {"arm64"},
+        )
+
+        self.assertEqual(
+            args,
+            ["/Applications/Adobe Photoshop/Photoshop"],
+        )
+        self.assertIsNone(arch)
+
+    def test_uses_rosetta_for_x86_only_photoshop(self):
+        args, arch = launch_utils.get_macos_launch_args(
+            ["/Applications/Adobe Photoshop/Photoshop", "--flag"],
+            ["x86_64"],
+            {"arm64"},
+        )
+
+        self.assertEqual(
+            args,
+            [
+                "arch",
+                "-x86_64",
+                "/Applications/Adobe Photoshop/Photoshop",
+                "--flag",
+            ],
+        )
+        self.assertEqual(arch, "x86_64")
+
+    def test_keeps_arguments_when_architecture_detection_fails(self):
+        original_args = ["/Applications/Adobe Photoshop/Photoshop"]
+
+        args, arch = launch_utils.get_macos_launch_args(
+            original_args,
+            [],
+            {"arm64"},
+        )
+
+        self.assertEqual(args, original_args)
+        self.assertIsNone(arch)
+        self.assertIsNot(args, original_args)
+
+    def test_keeps_arguments_when_process_architecture_is_unknown(self):
+        original_args = ["/Applications/Adobe Photoshop/Photoshop"]
+
+        args, arch = launch_utils.get_macos_launch_args(
+            original_args,
+            ["x86_64", "arm64"],
+            set(),
+        )
+
+        self.assertEqual(args, original_args)
+        self.assertIsNone(arch)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Fix macOS Photoshop architecture selection

## Changelog Description

Launch Photoshop with a compatible architecture on macOS instead of always
forcing `x86_64`.

## Additional review information

The current launcher prefixes every macOS invocation with
`arch -x86_64`. This prevents a universal Photoshop binary from launching
natively as `arm64`.

The updated launcher reads the architectures supported by Photoshop and the
running Python executable with `lipo -archs`:

- If the binaries share an architecture, Photoshop launches normally and
  macOS selects the native architecture.
- If they do not share an architecture, the launcher prefixes the command
  with the architecture supported by Photoshop. This preserves Rosetta
  support for an x86-only Photoshop installation.
- If architecture detection fails, the launcher falls back to the original
  command instead of guessing an architecture.

Resolves https://github.com/ynput/ayon-photoshop/issues/91

## Testing notes

Run:

```shell
python -m unittest discover -s tests -v
python -m compileall -q client/ayon_photoshop/api tests
```

Covered cases:

1. Universal Photoshop plus arm64 Python launches natively.
2. x86-only Photoshop plus arm64 Python launches through Rosetta.
3. Failed Photoshop architecture detection preserves the original command.
4. Failed Python architecture detection preserves the original command.

Hardware verification on an Apple Silicon Mac is still recommended before
merge.
