### PR TITLE
Replace qargparse with attribute definitions

### DIFF
--- a/client/ayon_photoshop/plugins/load/load_image_from_sequence.py
+++ b/client/ayon_photoshop/plugins/load/load_image_from_sequence.py
@@ -1,7 +1,6 @@
 import os
 
-import qargparse
-
+from ayon_core.lib import EnumDef
 from ayon_photoshop import api as photoshop
 from ayon_photoshop.api import get_unique_layer_name
 
@@ -78,11 +77,11 @@ class ImageFromSequenceLoader(photoshop.PhotoshopLoader):
             return []
 
         return [
-            qargparse.Choice(
+            EnumDef(
                 "frame",
                 label="Select specific file",
                 items=files,
-                default=0,
+                default=files[0],
                 help="Which frame should be loaded?"
             )
         ]

--- a/client/ayon_photoshop/plugins/load/load_image_from_sequence.py
+++ b/client/ayon_photoshop/plugins/load/load_image_from_sequence.py
@@ -82,7 +82,7 @@ class ImageFromSequenceLoader(photoshop.PhotoshopLoader):
                 label="Select specific file",
                 items=files,
                 default=files[0],
-                help="Which frame should be loaded?"
+                tooltip="Which frame should be loaded?"
             )
         ]
 


### PR DESCRIPTION
## Changelog Description

Replace qargparse with attribute definitions

## Additional review information

Clean up usage of `qargparse` and starting using AYON's attribute definitons.

## Testing notes:

1. Load options should still work
